### PR TITLE
Add JUnit Jupiter support and module test classes

### DIFF
--- a/H2XlsReport/src/test/java/com/hoffnungland/poi/corner/h2xlsreport/AppTest.java
+++ b/H2XlsReport/src/test/java/com/hoffnungland/poi/corner/h2xlsreport/AppTest.java
@@ -1,20 +1,13 @@
 package com.hoffnungland.poi.corner.h2xlsreport;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-{
-    /**
-     * Rigorous Test :-)
-     */
+class AppTest {
+
     @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/JSONXlsReport/src/test/java/com/hoffnungland/poi/corner/jsonxlsloader/AppTest.java
+++ b/JSONXlsReport/src/test/java/com/hoffnungland/poi/corner/jsonxlsloader/AppTest.java
@@ -1,20 +1,13 @@
 package com.hoffnungland.poi.corner.jsonxlsloader;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-{
-    /**
-     * Rigorous Test :-)
-     */
+class AppTest {
+
     @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/OrcXlsLoader/src/test/java/com/hoffnungland/sdc/AppTest.java
+++ b/OrcXlsLoader/src/test/java/com/hoffnungland/sdc/AppTest.java
@@ -1,20 +1,13 @@
 package com.hoffnungland.sdc;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-{
-    /**
-     * Rigorous Test :-)
-     */
+class AppTest {
+
     @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/OrcXlsReport/src/test/java/com/hoffnungland/poi/corner/orcxlsreport/AppTest.java
+++ b/OrcXlsReport/src/test/java/com/hoffnungland/poi/corner/orcxlsreport/AppTest.java
@@ -1,38 +1,13 @@
 package com.hoffnungland.poi.corner.orcxlsreport;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-    extends TestCase
-{
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
-    }
+import org.junit.jupiter.api.Test;
 
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
-    }
+class AppTest {
 
-    /**
-     * Rigourous Test :-)
-     */
-    public void testApp()
-    {
-        assertTrue( true );
+    @Test
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/PDFCreator/src/test/java/com/hoffnungland/poi/corner/pdfcreator/AppTest.java
+++ b/PDFCreator/src/test/java/com/hoffnungland/poi/corner/pdfcreator/AppTest.java
@@ -1,20 +1,13 @@
 package com.hoffnungland.poi.corner.pdfcreator;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-{
-    /**
-     * Rigorous Test :-)
-     */
+class AppTest {
+
     @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/PgXlsReport/src/test/java/com/hoffnungland/poi/corner/pgxlsreport/AppTest.java
+++ b/PgXlsReport/src/test/java/com/hoffnungland/poi/corner/pgxlsreport/AppTest.java
@@ -1,4 +1,4 @@
-package com.hoffnungland.poi.corner.extractshapesvsdx;
+package com.hoffnungland.poi.corner.pgxlsreport;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/XlsReport/src/test/java/com/hoffnungland/poi/corner/dbxlsreport/AppTest.java
+++ b/XlsReport/src/test/java/com/hoffnungland/poi/corner/dbxlsreport/AppTest.java
@@ -1,4 +1,4 @@
-package com.hoffnungland.poi.corner.extractshapesvsdx;
+package com.hoffnungland.poi.corner.dbxlsreport;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/XmlXlsReport/src/test/java/com/hoffnungland/poi/corner/xmlxlsreport/AppTest.java
+++ b/XmlXlsReport/src/test/java/com/hoffnungland/poi/corner/xmlxlsreport/AppTest.java
@@ -1,38 +1,13 @@
 package com.hoffnungland.poi.corner.xmlxlsreport;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-    extends TestCase
-{
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
-    }
+import org.junit.jupiter.api.Test;
 
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
-    }
+class AppTest {
 
-    /**
-     * Rigourous Test :-)
-     */
-    public void testApp()
-    {
-        assertTrue( true );
+    @Test
+    void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
           <artifactId>maven-jarsigner-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -131,11 +136,10 @@
     </plugins>
   </build>
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/junit/junit -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.12.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Motivation
- Modernize test infrastructure by moving from legacy JUnit 3/4 to JUnit 5 so new tests use JUnit Jupiter features and are discovered by modern Maven tooling.
- Ensure modules that lacked basic smoke tests have minimal `AppTest` classes to avoid empty-test failures and to provide a consistent test baseline.

### Description
- Replaced the legacy `junit:junit` test dependency with `org.junit.jupiter:junit-jupiter:5.12.2` in the top-level `pom.xml` and added `maven-surefire-plugin` `3.2.5` to `pluginManagement` so JUnit 5 tests are executed consistently.
- Updated existing module test classes from JUnit 3/4 style to JUnit Jupiter (`org.junit.jupiter.api.Test` + `Assertions.assertTrue`) across modules including `ExtractShapesVsdx`, `OrcXlsReport`, `XmlXlsReport`, `H2XlsReport`, `PDFCreator`, `JSONXlsReport`, and `OrcXlsLoader`.
- Added new minimal JUnit Jupiter `AppTest` classes for `XlsReport` and `PgXlsReport` modules to provide basic smoke tests.
- Kept existing build configuration and other dependencies unchanged except for the introduced test dependency and surefire plugin entry.

### Testing
- Ran `mvn test` from the repository root to validate the change in this environment.
- The build was blocked by plugin resolution errors and failed with Maven unable to download `org.apache.maven.plugins:maven-enforcer-plugin:3.2.1` from Maven Central (HTTP 403 Forbidden), so automated test execution could not complete.
- The added JUnit Jupiter test classes are syntactically valid and should run when Maven can resolve plugins and dependencies normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68afa89b0832ead2141586dadf6be)