### PR TITLE
Upgrade POICorner Maven configuration to Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
   </prerequisites>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.source.version>21</java.source.version>
-    <java.target.version>21</java.target.version>
+    <java.source.version>25</java.source.version>
+    <java.target.version>25</java.target.version>
   </properties>
   <build>
     <pluginManagement>
@@ -82,7 +82,7 @@
                   <version>3.2.5</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>1.8.0</version>
+                  <version>[25,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
### Motivation
- Raise the project Java language level to Java 25 so modules can use new language and platform features by default.
- Make the build reject older JDKs by tightening the Maven Enforcer Java requirement to explicitly require Java 25 or newer.

### Description
- Updated the root `pom.xml` properties `java.source.version` and `java.target.version` from `21` to `25`.
- Updated the Maven Enforcer `requireJavaVersion` rule in the root `pom.xml` to `"[25,)"` so the build requires Java 25+.

### Testing
- Ran `mvn -q -DskipTests validate` to validate the build configuration, which could not complete because Maven failed to resolve `org.apache.maven.plugins:maven-enforcer-plugin:3.2.1` from Maven Central (HTTP 403).
- No further automated tests were run because the environment could not complete plugin resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68beda50c832e81696256b15fc896)