### PR TITLE
Add Javadocs for XML XLS report classes

### DIFF
--- a/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/NodeSheet.java
+++ b/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/NodeSheet.java
@@ -13,14 +13,32 @@ public class NodeSheet {
 	
 	private static final Logger logger = LogManager.getLogger(NodeSheet.class);
 	
+	/**
+	 * Mapping between worksheet header name and zero-based column index.
+	 */
 	public Map<String, Integer> mapOfHeader;
+	/**
+	 * Backing worksheet associated with this node descriptor.
+	 */
 	public XSSFSheet sheet;
+	/**
+	 * Current working row for write operations.
+	 */
 	public int workingRow = 0;
 	
+	/**
+	 * Creates a node-sheet wrapper for a workbook sheet.
+	 *
+	 * @param sheet target worksheet.
+	 */
 	public NodeSheet(XSSFSheet sheet) {
 		this.sheet = sheet;
 	}
 
+	/**
+	 * Loads worksheet headers from the first row and stores them into
+	 * {@link #mapOfHeader}.
+	 */
 	public void loadHeader(){
 		logger.traceEntry();
 		this.mapOfHeader = new HashMap<String, Integer>();

--- a/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/XmlReportWorkbook.java
+++ b/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/XmlReportWorkbook.java
@@ -17,26 +17,54 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 public class XmlReportWorkbook extends XSSFWorkbook {
 	private static final Logger logger = LogManager.getLogger(XmlReportWorkbook.class);
 	
-	//Create list of NodeSheet index by sheet name
+	/**
+	 * Index of {@link NodeSheet} instances keyed by worksheet name.
+	 */
 	public Map<String, NodeSheet> mapOfNodesSheets;
 	
+	/**
+	 * Creates an empty workbook instance.
+	 */
 	public XmlReportWorkbook() {
 		super();
 	}
 
+	/**
+	 * Creates a workbook from the supplied template file.
+	 *
+	 * @param file template file to load.
+	 * @throws IOException if the file cannot be read.
+	 * @throws InvalidFormatException if the file is not a valid workbook format.
+	 */
 	public XmlReportWorkbook(File file) throws IOException, InvalidFormatException {
 		super(file);
 	}
 	
+	/**
+	 * Creates a workbook from the provided input stream.
+	 *
+	 * @param inS stream that contains workbook data.
+	 * @throws IOException if the workbook cannot be read.
+	 */
 	public XmlReportWorkbook(InputStream inS) throws IOException {
 		super(inS);
 	}
 	
+	/**
+	 * Creates a workbook from the path of an existing template file.
+	 *
+	 * @param path absolute or relative path of the workbook template.
+	 * @throws IOException if the workbook cannot be read.
+	 */
 	public XmlReportWorkbook(String path) throws IOException {
 		super(path);
 		
 	}
 
+	/**
+	 * Initializes {@link #mapOfNodesSheets} by scanning every worksheet and loading
+	 * the first-row header map for each sheet.
+	 */
 	public void initSheets(){
 		logger.traceEntry();
 		this.mapOfNodesSheets = new HashMap<String, NodeSheet>();

--- a/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/XmlToXlsManager.java
+++ b/XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/XmlToXlsManager.java
@@ -66,6 +66,14 @@ public class XmlToXlsManager extends ExcelManager {
 		super(name);
 	}
 
+	/**
+	 * Loads an XLSX template and initializes sheet/header metadata used while
+	 * writing relational and XML data.
+	 *
+	 * @param fileName path to the workbook template.
+	 * @throws IOException if the template cannot be read.
+	 * @throws ParserConfigurationException if XML parser creation fails.
+	 */
 	public void loadTemplate(String fileName) throws IOException, ParserConfigurationException{
 
 		logger.traceEntry();
@@ -105,6 +113,20 @@ public class XmlToXlsManager extends ExcelManager {
 	}
 
 
+	/**
+	 * Writes one JDBC row into the workbook:
+	 * <ul>
+	 *   <li>regular columns are written in the "Table" sheet using header mapping;</li>
+	 *   <li>the column matching {@code rootNodeName} is parsed as XML and expanded
+	 *   into child sheets.</li>
+	 * </ul>
+	 *
+	 * @param resRs source result-set row.
+	 * @param rootNodeName column label that contains the XML root payload.
+	 * @throws SQLException if result-set access fails.
+	 * @throws IOException if reading CLOB/XML content fails.
+	 * @throws SAXException if XML parsing fails.
+	 */
 	public void insertResultSet(ResultSet resRs, String rootNodeName) throws SQLException, IOException, SAXException{
 
 		logger.traceEntry();
@@ -249,6 +271,13 @@ public class XmlToXlsManager extends ExcelManager {
 
 	}
 
+	/**
+	 * Writes one XML node value to the mapped workbook cell, creating child-sheet
+	 * hyperlinks and recursively traversing nested nodes when required.
+	 *
+	 * @param xmlNode xml node to process.
+	 * @param nodeSheet target node sheet descriptor.
+	 */
 	private void nodeToCellValue(Node xmlNode, NodeSheet nodeSheet){
 		int columnPosition = nodeSheet.mapOfHeader.get(xmlNode.getNodeName()).intValue();
 		
@@ -324,6 +353,13 @@ public class XmlToXlsManager extends ExcelManager {
 		contentCell.setCellStyle(this.defaultCellStyle);
 	}
 	
+	/**
+	 * Recursively iterates through node children and dispatches each supported child
+	 * to {@link #nodeToCellValue(Node, NodeSheet)}.
+	 *
+	 * @param xmlNode parent node to traverse.
+	 * @param nodeSheet target sheet descriptor.
+	 */
 	private void crawlNodes(Node xmlNode, NodeSheet nodeSheet){
 
 		logger.traceEntry();
@@ -424,6 +460,9 @@ public class XmlToXlsManager extends ExcelManager {
 
 	/**
 	 * Flush the workbook data into the file and close the workbook.
+	 *
+	 * @param targetPath destination directory prefix; when empty, writes to the
+	 *                   current working directory.
 	 * @author manuel.m.speranza
 	 * @since 31-08-2016
 	 */


### PR DESCRIPTION
### Motivation
- Improve code readability and maintainer guidance by documenting the XML-to-XLS workbook model and behaviors used when loading templates and writing XML/DB data into sheets.
- Clarify header mapping, working-row semantics and traversal responsibilities to reduce ambiguity when extending or debugging the XML export flow.

### Description
- Added class/field/constructor Javadocs to `XmlReportWorkbook` to document the workbook constructors, `mapOfNodesSheets` index and `initSheets` lifecycle.
- Added field/constructor/method Javadocs to `NodeSheet` to describe header mapping, backing worksheet and `workingRow` semantics and to document `loadHeader()` behavior.
- Expanded method-level Javadocs in `XmlToXlsManager` for `loadTemplate`, `insertResultSet`, `nodeToCellValue`, `crawlNodes` and `finalWrite`, including parameter and exception descriptions and notes about XML traversal and child-sheet hyperlinking.
- Updated source files: `XmlXlsReport/src/main/java/com/hoffnungland/poi/corner/xmlxlsreport/XmlReportWorkbook.java`, `.../NodeSheet.java`, and `.../XmlToXlsManager.java` to add the documentation.

### Testing
- Ran `mvn -q -pl XmlXlsReport test`, which failed in this environment due to dependency resolution (`maven-enforcer-plugin:3.2.1` returned HTTP 403 from Maven Central), so module tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68bfe7708832eaa412f60e6757aa9)